### PR TITLE
Add indexes for top posts lookups and concurrent refreshes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ yarn dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result. It'll update as you make changes.
 
+## Database maintenance
+
+Schema changes and materialized-view refresh instructions live in
+[`database/README.md`](database/README.md). Database migrations are applied
+manually and are not part of the Vercel build.
+
 ## Acknowledgements
 
 Originally I used Jason Baumgartner's free API on ([pushshift.io](https://pushshift.io/)) for fetching Reddit history. Unfortunately, the project died in 2023 in the wake of Reddit's changes to their API pricing.

--- a/database/README.md
+++ b/database/README.md
@@ -1,0 +1,62 @@
+# Database operations
+
+Database migrations are plain SQL files intended to be run with `psql`. They
+are not executed by the application or during a Vercel deployment.
+
+## Connect
+
+The application uses the `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, and
+`DB_DATABASE` environment variables. With those variables loaded into your
+shell, run a migration with:
+
+```bash
+PGPASSWORD="$DB_PASSWORD" psql \
+  --host "$DB_HOST" \
+  --port "$DB_PORT" \
+  --username "$DB_USER" \
+  --dbname "$DB_DATABASE" \
+  --set ON_ERROR_STOP=1 \
+  --file database/migrations/20260809_add_top_posts_indexes.sql
+```
+
+Do not commit database credentials or put them directly in shell history.
+
+## Refresh `top_posts`
+
+The `top_posts_id_uidx` unique index makes a concurrent refresh possible. A
+concurrent refresh keeps the existing materialized-view contents readable while
+PostgreSQL builds the replacement:
+
+```sql
+REFRESH MATERIALIZED VIEW CONCURRENTLY public.top_posts;
+```
+
+Run only one refresh at a time. PostgreSQL requires the view to already be
+populated, and the refresh will fail if the source data would produce duplicate
+or null `id` values. The source `posts.id` primary key currently guarantees
+that each selected row has a unique, non-null ID.
+
+## Verify the indexes
+
+Check that both indexes are present, valid, and ready:
+
+```sql
+SELECT
+  indexrelid::regclass AS index_name,
+  indisunique,
+  indisvalid,
+  indisready
+FROM pg_index
+WHERE indrelid = 'public.top_posts'::regclass
+ORDER BY indexrelid::regclass::text;
+```
+
+Date lookups should use `top_posts_created_date_idx` rather than a sequential
+scan:
+
+```sql
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT *
+FROM public.top_posts
+WHERE created_date = DATE '2018-06-12';
+```

--- a/database/migrations/20260809_add_top_posts_indexes.sql
+++ b/database/migrations/20260809_add_top_posts_indexes.sql
@@ -1,0 +1,13 @@
+-- Speed up the date-filtered API query and allow non-blocking refreshes of the
+-- top_posts materialized view.
+--
+-- CREATE INDEX CONCURRENTLY cannot run inside a transaction. Run this file
+-- directly with psql; do not wrap it in BEGIN/COMMIT.
+
+SET statement_timeout = 0;
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS top_posts_id_uidx
+  ON public.top_posts (id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS top_posts_created_date_idx
+  ON public.top_posts (created_date);


### PR DESCRIPTION
## What changed

- add an idempotent SQL migration that creates `top_posts` indexes concurrently
- add a unique index on `id` so `REFRESH MATERIALIZED VIEW CONCURRENTLY` is supported
- add a `created_date` index for the production API lookup
- document migration execution, concurrent refreshes, and verification queries

## Why

`top_posts` had no indexes, so every date request performed a parallel
sequential scan over the 298 MB materialized view. The materialized view also
lacked the qualifying unique index PostgreSQL requires for concurrent refreshes.

## Production verification

- confirmed all 324,451 materialized-view rows have unique, non-null IDs
- confirmed source `posts.id` is a primary key with 1,339,180 unique, non-null IDs
- applied the migration to Neon using `CREATE INDEX CONCURRENTLY`
- reran the migration successfully to verify idempotence
- confirmed both indexes are valid and ready
- representative 2018-06-12 lookup changed from a 152.081 ms parallel
  sequential scan (38,094 buffers) to a 0.081 ms index scan (13 cached buffers),
  returning the same 60 unique rows

## Checks

- `git diff --check`
- live Neon schema and duplicate checks
- live `EXPLAIN (ANALYZE, BUFFERS)` before and after migration
